### PR TITLE
Don't use Unix paths in npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An API for interacting with Swagger documents.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js"
+    "test": "gulp"
   },
   "keywords": [
     "swagger"


### PR DESCRIPTION
npm will use local `.bin` folder. Please see https://docs.npmjs.com/misc/scripts#path